### PR TITLE
Add self-healing restart policy for MinIO service

### DIFF
--- a/roles/microk8s-node/tasks/main.yml
+++ b/roles/microk8s-node/tasks/main.yml
@@ -13,6 +13,9 @@
   register: microk8s_status
   until: microk8s_status.stdout.find('is running') != -1
   changed_when: no
+  # Run the read-only status check for real in check mode too — a skipped
+  # shell task leaves stdout empty and the until-condition can never pass
+  check_mode: no
   tags: microk8s-node
 
 - name: Create kubectl Snap alias

--- a/roles/minio-server/handlers/main.yml
+++ b/roles/minio-server/handlers/main.yml
@@ -3,7 +3,6 @@
 - name: Reload systemd daemon
   ansible.builtin.systemd:
     daemon_reload: yes
-  check_mode: no
 
 - name: Restart MinIO service
   ansible.builtin.systemd:

--- a/roles/minio-server/handlers/main.yml
+++ b/roles/minio-server/handlers/main.yml
@@ -1,5 +1,10 @@
 ---
 
+- name: Reload systemd daemon
+  ansible.builtin.systemd:
+    daemon_reload: yes
+  check_mode: no
+
 - name: Restart MinIO service
   ansible.builtin.systemd:
     name: minio

--- a/roles/minio-server/tasks/minio-server.yml
+++ b/roles/minio-server/tasks/minio-server.yml
@@ -13,6 +13,34 @@
   notify: Restart MinIO service
   tags: minio-server
 
+- name: Create MinIO service drop-in directory
+  ansible.builtin.file:
+    path: /etc/systemd/system/minio.service.d
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+  tags: minio-server
+
+- name: Configure MinIO service restart policy
+  ansible.builtin.copy:
+    dest: /etc/systemd/system/minio.service.d/override.conf
+    owner: root
+    group: root
+    mode: 0644
+    content: |
+      # The packaged unit restarts every 100 ms and gives up after 5 failed
+      # starts within 10 s, leaving the service permanently failed when it
+      # exits quickly at boot (LAN NIC without address or cluster peers not
+      # up yet). Retry every 10 s instead, and never stop retrying.
+      [Unit]
+      StartLimitIntervalSec=0
+
+      [Service]
+      RestartSec=10s
+  notify: Reload systemd daemon
+  tags: minio-server
+
 - name: Determine the designated initial master host
   ansible.builtin.set_fact:
     designated_host: '{{ (groups[minio_servers_group] | sort)[0] }}'


### PR DESCRIPTION
## Problem

The packaged `minio.service` unit has `Restart=always` but keeps the systemd defaults of `RestartSec=100ms` and a start rate limit of 5 starts per 10 s. When MinIO exits quickly at boot — LAN NIC without an address yet, or cluster peers not up — it burns all 5 attempts in about a second, hits the rate limit, and the unit enters a permanently failed state until someone runs `systemctl restart minio` by hand. This bit `a12c` after a reboot on 2026-08-06 (`ERROR Unable to configure server grid RPC services: grid: local host not found`, followed by `start request repeated too quickly`).

## Solution

Deploy a minimal systemd drop-in at `/etc/systemd/system/minio.service.d/override.conf` on all 4 nodes:

- `StartLimitIntervalSec=0` — systemd never gives up restarting the service
- `RestartSec=10s` — sane retry pacing instead of the 100 ms default

A drop-in survives package upgrades (no edits to `/usr/lib/systemd/system/minio.service`), and `Restart=always` is already set by the packaged unit so it is not repeated. Activation only requires `systemctl daemon-reload` (new handler) — no MinIO service restart, so the rollout has zero runtime impact; the policy takes effect from the next service exit or boot.

## Verification

CI runs the playbooks in `--check --diff` mode against the live servers, so the exact change is visible in the checks on this PR. After merge, CD applies it for real; expected end state per node:

```
$ systemctl show minio -p Restart -p RestartUSec -p StartLimitIntervalUSec
Restart=always
RestartUSec=10s
StartLimitIntervalUSec=0
```