### PR TITLE
Add smartmontools to base packages

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -105,6 +105,7 @@
       - make
       - gcc
       - xsel
+      - smartmontools
     autoremove: true
     state: present
   tags: common


### PR DESCRIPTION
Adds `smartmontools` to the `common` role's base package list so `smartctl` (and the `smartd` monitoring daemon) are provisioned on all nodes, instead of the ad-hoc installs done during the 2026-08-08 disk health review.

All 4 nodes already have the package installed manually, so the CD run will report `ok` (no change) on the servers — this PR just brings the provisioning code in sync with reality.

## SMART review 2026-08-08 (for the record)

| Node | Drive | Health | Wear | Written | Power-on hours | Temp | Errors |
|---|---|---|---|---|---|---|---|
| a12a | Samsung 870 8TB (SATA) | PASSED | 1% | ~30 TB | 20,900 | 39°C | 0 |
| a12a | Corsair MP600 8TB (NVMe) | PASSED | 4% | 47.5 TB | 20,832 | 44°C | 0 |
| a12b | Samsung 870 8TB | PASSED | 1% | ~30 TB | 20,830 | 39°C | 0 |
| a12b | Corsair MP600 8TB | PASSED | 4% | 47.7 TB | 20,886 | 42°C | 0 |
| a12c | Samsung 870 8TB | PASSED | 1% | ~30 TB | 27,103 | 49°C | 0 |
| a12c | Corsair MP600 4TB | PASSED | 8% | 54.2 TB | 27,038 | 56°C | 0 |
| a12c | Kingston SNV2S 4TB | PASSED | 0% | 512 KB | 5,907 | 53°C | 0 |
| a12d | Samsung 870 8TB | PASSED | 1% | ~30 TB | 20,893 | 51°C | 0 |
| a12d | Kingston SNV2S 4TB | PASSED | 0% | 51.9 TB | 5,235 | 59°C | 0 |
| a12d | Kingston SNV2S 4TB | PASSED | 0% | 512 KB | 5,314 | 57°C | 0 |

Notes:

- Zero error counters across all 10 drives (no reallocated/pending sectors, no media/data integrity errors) despite 30–77 unsafe shutdowns per drive from past power incidents.
- Worst wear is 8% (a12c Corsair, ~3 years of service) — negligible at current write rates.
- The second Kingston NVMe on a12c/a12d (512 KB written) is an LVM PV in `ubuntu-vg` with no LVs — 3.6 TB of untouched headroom per s3 node, by design.
- The s3-site drives run 10–15°C hotter than s1 (49–59°C vs 39–44°C) — within spec, but worth keeping an eye on the site cooling.