### PR TITLE
Bump GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/ansible-cd.yml
+++ b/.github/workflows/ansible-cd.yml
@@ -8,10 +8,10 @@ jobs:
   run-ansible-playbook:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
 
       - name: Run 0-bootstrap.yml playbook
-        uses: dawidd6/action-ansible-playbook@v2.8.0
+        uses: dawidd6/action-ansible-playbook@v9
         with:
           playbook: 0-bootstrap.yml
           key: ${{ secrets.SSH_PRIVATE_KEY }}
@@ -25,7 +25,7 @@ jobs:
             --diff
 
       - name: Run 1-microk8s-cluster.yml playbook
-        uses: dawidd6/action-ansible-playbook@v2.8.0
+        uses: dawidd6/action-ansible-playbook@v9
         with:
           playbook: 1-microk8s-cluster.yml
           key: ${{ secrets.SSH_PRIVATE_KEY }}
@@ -39,7 +39,7 @@ jobs:
             --diff
 
       - name: Run 2-minio-servers.yml playbook
-        uses: dawidd6/action-ansible-playbook@v2.8.0
+        uses: dawidd6/action-ansible-playbook@v9
         with:
           playbook: 2-minio-servers.yml
           key: ${{ secrets.SSH_PRIVATE_KEY }}
@@ -54,7 +54,7 @@ jobs:
             -e @secrets.yml
 
       - name: Run 3-minio-oidc.yml playbook
-        uses: dawidd6/action-ansible-playbook@v2.8.0
+        uses: dawidd6/action-ansible-playbook@v9
         with:
           playbook: 3-minio-oidc.yml
           key: ${{ secrets.SSH_PRIVATE_KEY }}

--- a/.github/workflows/ansible-ci.yml
+++ b/.github/workflows/ansible-ci.yml
@@ -7,10 +7,10 @@ jobs:
   check-ansible-playbook:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
 
       - name: Check 0-bootstrap.yml playbook
-        uses: dawidd6/action-ansible-playbook@v2.8.0
+        uses: dawidd6/action-ansible-playbook@v9
         with:
           playbook: 0-bootstrap.yml
           key: ${{ secrets.SSH_PRIVATE_KEY }}
@@ -25,7 +25,7 @@ jobs:
             --check
 
       - name: Check 1-microk8s-cluster.yml playbook
-        uses: dawidd6/action-ansible-playbook@v2.8.0
+        uses: dawidd6/action-ansible-playbook@v9
         with:
           playbook: 1-microk8s-cluster.yml
           key: ${{ secrets.SSH_PRIVATE_KEY }}
@@ -40,7 +40,7 @@ jobs:
             --check
 
       - name: Check 2-minio-servers.yml playbook
-        uses: dawidd6/action-ansible-playbook@v2.8.0
+        uses: dawidd6/action-ansible-playbook@v9
         with:
           playbook: 2-minio-servers.yml
           key: ${{ secrets.SSH_PRIVATE_KEY }}
@@ -56,7 +56,7 @@ jobs:
             -e @secrets.yml
 
       - name: Check 3-minio-oidc.yml playbook
-        uses: dawidd6/action-ansible-playbook@v2.8.0
+        uses: dawidd6/action-ansible-playbook@v9
         with:
           playbook: 3-minio-oidc.yml
           key: ${{ secrets.SSH_PRIVATE_KEY }}

--- a/.github/workflows/test-arc-runner.yml
+++ b/.github/workflows/test-arc-runner.yml
@@ -66,7 +66,7 @@ jobs:
           echo "curl: $(curl --version | head -1)"
 
       - name: Test checkout action
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Verify repository checkout
         run: |


### PR DESCRIPTION
Every workflow run currently prints a deprecation warning because GitHub [deprecated Node 20 on Actions runners in September 2025](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) and force-runs actions declaring `node20` (or older) with Node 24.

- `actions/checkout`: v3/v4 → v5 (declares `node24`)
- `dawidd6/action-ansible-playbook`: v2.8.0 → v9 (declares `node24`; the project switched to major-only tags after v2.8.0)

All action inputs used in our workflows (`playbook`, `key`, `known_hosts`, `vault_password`, `options`) are unchanged in v9, so no other workflow changes are needed. The CI run on this PR doubles as verification that the warnings are gone.