### PR TITLE
Backport common-role and MicroK8s improvements from frigate-microk8s-ansible

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ This Ansible project deploys and manages the S3 object storage infrastructure th
 
 ## Development Environment Setup
 
-1. Create Python virtual environment and install dependencies:
+1. Create Python virtual environment (Python 3.12 or newer) and install dependencies:
    ```bash
    python3 -m venv venv
    source venv/bin/activate
@@ -184,20 +184,24 @@ See README.md section "Add OpenID Connect using Auth0" for complete setup instru
 - Configures sysadmin accounts and Ansible service account
 - Enforces strict SSH security (no root login, AllowUsers whitelist, no password auth for sudo)
 - Removes ~/.ssh/authorized_keys for root user
-- Sets Europe/Stockholm timezone
-- Installs essential packages
+- Sets Europe/Stockholm timezone and enforces the en_US.UTF-8 system locale
+- Installs essential packages (incl. htop and the ubuntu-server metapackage, so the baseline
+  does not depend on the OS installer's package selection)
 - Removes firewalld (conflicts with Calico)
 
 **`microk8s-node`** - MicroK8s installation
 - Installs MicroK8s via snap (stable channel)
 - Creates kubectl snap alias
 - Adds users to microk8s group
-- Prints clustering instructions (manual execution required)
+- Prints clustering instructions when the inventory group holds more than one host (manual
+  execution required); a one-host group collapses cleanly to a single-node setup
 
 **`microk8s-cluster`** - Kubernetes configuration
 - Enables add-ons on designated master first, then other nodes
 - Configures user kubectl access
 - Deploys cert-manager, dashboard ingress, CoreDNS settings
+- Site resources are gated by the `create_letsencrypt_issuer` and `create_dashboard_ingress`
+  task toggles (both default to enabled here; disabled in frigate-microk8s-ansible)
 - Task files: `user-configurations.yml`, `k8s-configurations.yml`
 
 **`minio-server`** - MinIO S3 service

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Clone the repo:
     git clone git@github.com:OwnTube-tv/minio-microk8s-ansible.git
     cd minio-microk8s-ansible/
 
-Create a virtual environment and install the dependencies:
+Create a virtual environment (Python 3.12 or newer) and install the dependencies:
 
     python3 -m venv venv
     source venv/bin/activate
@@ -38,7 +38,7 @@ Run through the bootstrap playbook in `--check` mode to verify that provisioning
 
 The initial setup steps for a live deployment are as follows:
 
-1. Run the `0-bootstrap.yml` playbook to prepare the server baseline for MinIO and MicroK8s setup:
+1. Run the `0-bootstrap.yml` playbook to prepare the server baseline and install MicroK8s:
 
     ```shell
     ansible-playbook 0-bootstrap.yml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 ansible==9.3.0
 ansible-core==2.16.4
-cffi==1.16.0
+cffi==2.1.1
 cryptography==42.0.5
 Jinja2==3.1.3
 MarkupSafe==2.1.5

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -101,6 +101,7 @@
   ansible.builtin.apt:
     name:
       - acl
+      - htop
       - tree
       - dlocate
       - jq
@@ -118,6 +119,7 @@
       - gcc
       - xsel
       - smartmontools
+      - ubuntu-server
     autoremove: true
     state: present
   tags: common

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -85,6 +85,18 @@
     name: Europe/Stockholm
   tags: common
 
+- name: Generate the en_US.UTF-8 locale
+  community.general.locale_gen:
+    name: en_US.UTF-8
+    state: present
+  tags: common
+
+- name: Set en_US.UTF-8 as default system locale
+  ansible.builtin.copy:
+    content: "LANG=en_US.UTF-8\n"
+    dest: /etc/default/locale
+  tags: common
+
 - name: Install base packages
   ansible.builtin.apt:
     name:

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -101,6 +101,7 @@
   ansible.builtin.apt:
     name:
       - acl
+      - btop
       - htop
       - tree
       - dlocate
@@ -110,6 +111,7 @@
       - unzip
       - wget
       - net-tools
+      - nethogs
       - parallel
       - inetutils-traceroute
       - python3-venv

--- a/roles/microk8s-cluster/defaults/main.yml
+++ b/roles/microk8s-cluster/defaults/main.yml
@@ -17,4 +17,8 @@ microk8s_plugins:
   metrics-server: yes
   host-access: yes
 
+create_letsencrypt_issuer: yes
+
+create_dashboard_ingress: yes
+
 ...

--- a/roles/microk8s-cluster/tasks/k8s-configurations.yml
+++ b/roles/microk8s-cluster/tasks/k8s-configurations.yml
@@ -18,6 +18,7 @@
   kubernetes.core.k8s:
     definition: "{{ lookup('file', 'letsencrypt-cluster-issuer.yml') | from_yaml }}"
     state: present
+  when: create_letsencrypt_issuer
   tags: microk8s-cluster
 
 - name: Add 'host.local' to CoreDNS ConfigMap for MicroK8s 'host-access' add-on compatibility
@@ -30,12 +31,14 @@
   kubernetes.core.k8s:
     definition: "{{ lookup('file', 'k8s-dashboard-ingress.yml') | from_yaml }}"
     state: present
+  when: create_dashboard_ingress
   tags: microk8s-cluster
 
 - name: Create long-lived token secret for Kubernetes Dashboard (K8s 1.24+)
   kubernetes.core.k8s:
     definition: "{{ lookup('file', 'k8s-dashboard-token.yml') | from_yaml }}"
     state: present
+  when: create_dashboard_ingress
   tags: microk8s-cluster
 
 ...

--- a/roles/microk8s-node/tasks/main.yml
+++ b/roles/microk8s-node/tasks/main.yml
@@ -47,7 +47,9 @@
       {{ hostvars[inventory_hostname].ansible_default_ipv4.address }} via SSH and run
       'microk8s add-node' for each of the other nodes per the https://microk8s.io/docs/clustering
       documentation.
-  when: inventory_hostname == designated_host
+  when:
+    - groups[microk8s_servers_group] | length > 1
+    - inventory_hostname == designated_host
   tags: microk8s-node
 
 - name: Print message about joining the other MicroK8s nodes to the designated/first node

--- a/roles/minio-server/tasks/minio-disks.yml
+++ b/roles/minio-server/tasks/minio-disks.yml
@@ -3,6 +3,8 @@
 - name: Check if the 'minio_vg_device' is a block device
   ansible.builtin.stat:
     path: "{{ minio_vg_device }}"
+    # Follow symlinks — /dev/disk/by-id/* paths are links to the real device
+    follow: yes
   register: minio_vg_device_stat
   tags: minio-disks
 


### PR DESCRIPTION
Backports from the new [frigate-microk8s-ansible](https://github.com/OwnTube-tv/frigate-microk8s-ansible) project, where the `common`, `microk8s-node` and `microk8s-cluster` roles are reused for a standalone single-node MicroK8s server. All changes are no-ops for the a12 fleet — they codify what was previously implicit from the OS installation:

- **Locale management in `common`**: generate `en_US.UTF-8` and set it in `/etc/default/locale`. The a12 nodes only have this because it was chosen at OS install; a stock Ubuntu 24.04 install defaults to `C.UTF-8`.
- **`htop` + `ubuntu-server` metapackage in base packages**: the a12 nodes get htop/tmux/git/vim/xfsprogs etc. implicitly via the installer's full `ubuntu-server` selection — a minimized install lacks them. Declaring the metapackage makes the baseline independent of installation flavor.
- **Single-node adaptability for the MicroK8s roles**: clustering instructions only print when the inventory group holds more than one host, and the site resources in `k8s-configurations.yml` (Let's Encrypt ClusterIssuer, dashboard ingress/token) are gated by new `create_letsencrypt_issuer` / `create_dashboard_ingress` toggles defaulting to enabled. With this, `diff -ru` between the two repos' roles shows only intended deltas.
- **cffi 1.16.0 → 2.1.1** (no longer builds on current Python) plus corrected setup docs: Python 3.12+ noted, and README now correctly states that `0-bootstrap.yml` installs MicroK8s.

CLAUDE.md role descriptions are synced with the above.