### PR TITLE
Consolidate cluster nodes onto site `a12-eoc-s3`

### DIFF
--- a/.github/workflows/ansible-cd.yml
+++ b/.github/workflows/ansible-cd.yml
@@ -16,10 +16,10 @@ jobs:
           playbook: 0-bootstrap.yml
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           known_hosts: |
-            [83.233.237.206]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGnXbhMpfFhusPWbl0OhXDjO9m0XT51FWF7PowVNOVg/
+            [83.233.237.207]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGnXbhMpfFhusPWbl0OhXDjO9m0XT51FWF7PowVNOVg/
             [83.233.237.208]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKSP+L5mjXBT5UqCi9/rHWFAeMCqhGyxYVbSQfmDkNuB
-            [83.233.237.207]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICK+q9cT0xsLeMQT/XI7DpTYB8+XX21h1vOWk+9/JyFx
-            [83.233.237.209]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL5bwRDW4XzjrPytPvrRb/YFVrNZdXbgwg6+uOJG+Hji
+            [83.233.237.209]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICK+q9cT0xsLeMQT/XI7DpTYB8+XX21h1vOWk+9/JyFx
+            [83.233.237.210]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL5bwRDW4XzjrPytPvrRb/YFVrNZdXbgwg6+uOJG+Hji
           vault_password: ${{ secrets.VAULT_PASSWORD }}
           options: |
             --diff
@@ -30,10 +30,10 @@ jobs:
           playbook: 1-microk8s-cluster.yml
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           known_hosts: |
-            [83.233.237.206]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGnXbhMpfFhusPWbl0OhXDjO9m0XT51FWF7PowVNOVg/
+            [83.233.237.207]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGnXbhMpfFhusPWbl0OhXDjO9m0XT51FWF7PowVNOVg/
             [83.233.237.208]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKSP+L5mjXBT5UqCi9/rHWFAeMCqhGyxYVbSQfmDkNuB
-            [83.233.237.207]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICK+q9cT0xsLeMQT/XI7DpTYB8+XX21h1vOWk+9/JyFx
-            [83.233.237.209]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL5bwRDW4XzjrPytPvrRb/YFVrNZdXbgwg6+uOJG+Hji
+            [83.233.237.209]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICK+q9cT0xsLeMQT/XI7DpTYB8+XX21h1vOWk+9/JyFx
+            [83.233.237.210]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL5bwRDW4XzjrPytPvrRb/YFVrNZdXbgwg6+uOJG+Hji
           vault_password: ${{ secrets.VAULT_PASSWORD }}
           options: |
             --diff
@@ -44,10 +44,10 @@ jobs:
           playbook: 2-minio-servers.yml
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           known_hosts: |
-            [83.233.237.206]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGnXbhMpfFhusPWbl0OhXDjO9m0XT51FWF7PowVNOVg/
+            [83.233.237.207]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGnXbhMpfFhusPWbl0OhXDjO9m0XT51FWF7PowVNOVg/
             [83.233.237.208]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKSP+L5mjXBT5UqCi9/rHWFAeMCqhGyxYVbSQfmDkNuB
-            [83.233.237.207]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICK+q9cT0xsLeMQT/XI7DpTYB8+XX21h1vOWk+9/JyFx
-            [83.233.237.209]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL5bwRDW4XzjrPytPvrRb/YFVrNZdXbgwg6+uOJG+Hji
+            [83.233.237.209]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICK+q9cT0xsLeMQT/XI7DpTYB8+XX21h1vOWk+9/JyFx
+            [83.233.237.210]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL5bwRDW4XzjrPytPvrRb/YFVrNZdXbgwg6+uOJG+Hji
           vault_password: ${{ secrets.VAULT_PASSWORD }}
           options: |
             --diff
@@ -59,10 +59,10 @@ jobs:
           playbook: 3-minio-oidc.yml
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           known_hosts: |
-            [83.233.237.206]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGnXbhMpfFhusPWbl0OhXDjO9m0XT51FWF7PowVNOVg/
+            [83.233.237.207]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGnXbhMpfFhusPWbl0OhXDjO9m0XT51FWF7PowVNOVg/
             [83.233.237.208]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKSP+L5mjXBT5UqCi9/rHWFAeMCqhGyxYVbSQfmDkNuB
-            [83.233.237.207]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICK+q9cT0xsLeMQT/XI7DpTYB8+XX21h1vOWk+9/JyFx
-            [83.233.237.209]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL5bwRDW4XzjrPytPvrRb/YFVrNZdXbgwg6+uOJG+Hji
+            [83.233.237.209]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICK+q9cT0xsLeMQT/XI7DpTYB8+XX21h1vOWk+9/JyFx
+            [83.233.237.210]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL5bwRDW4XzjrPytPvrRb/YFVrNZdXbgwg6+uOJG+Hji
           vault_password: ${{ secrets.VAULT_PASSWORD }}
           options: |
             --diff

--- a/.github/workflows/ansible-ci.yml
+++ b/.github/workflows/ansible-ci.yml
@@ -15,10 +15,10 @@ jobs:
           playbook: 0-bootstrap.yml
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           known_hosts: |
-            [83.233.237.206]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGnXbhMpfFhusPWbl0OhXDjO9m0XT51FWF7PowVNOVg/
+            [83.233.237.207]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGnXbhMpfFhusPWbl0OhXDjO9m0XT51FWF7PowVNOVg/
             [83.233.237.208]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKSP+L5mjXBT5UqCi9/rHWFAeMCqhGyxYVbSQfmDkNuB
-            [83.233.237.207]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICK+q9cT0xsLeMQT/XI7DpTYB8+XX21h1vOWk+9/JyFx
-            [83.233.237.209]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL5bwRDW4XzjrPytPvrRb/YFVrNZdXbgwg6+uOJG+Hji
+            [83.233.237.209]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICK+q9cT0xsLeMQT/XI7DpTYB8+XX21h1vOWk+9/JyFx
+            [83.233.237.210]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL5bwRDW4XzjrPytPvrRb/YFVrNZdXbgwg6+uOJG+Hji
           vault_password: ${{ secrets.VAULT_PASSWORD }}
           options: |
             --diff
@@ -30,10 +30,10 @@ jobs:
           playbook: 1-microk8s-cluster.yml
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           known_hosts: |
-            [83.233.237.206]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGnXbhMpfFhusPWbl0OhXDjO9m0XT51FWF7PowVNOVg/
+            [83.233.237.207]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGnXbhMpfFhusPWbl0OhXDjO9m0XT51FWF7PowVNOVg/
             [83.233.237.208]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKSP+L5mjXBT5UqCi9/rHWFAeMCqhGyxYVbSQfmDkNuB
-            [83.233.237.207]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICK+q9cT0xsLeMQT/XI7DpTYB8+XX21h1vOWk+9/JyFx
-            [83.233.237.209]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL5bwRDW4XzjrPytPvrRb/YFVrNZdXbgwg6+uOJG+Hji
+            [83.233.237.209]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICK+q9cT0xsLeMQT/XI7DpTYB8+XX21h1vOWk+9/JyFx
+            [83.233.237.210]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL5bwRDW4XzjrPytPvrRb/YFVrNZdXbgwg6+uOJG+Hji
           vault_password: ${{ secrets.VAULT_PASSWORD }}
           options: |
             --diff
@@ -45,10 +45,10 @@ jobs:
           playbook: 2-minio-servers.yml
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           known_hosts: |
-            [83.233.237.206]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGnXbhMpfFhusPWbl0OhXDjO9m0XT51FWF7PowVNOVg/
+            [83.233.237.207]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGnXbhMpfFhusPWbl0OhXDjO9m0XT51FWF7PowVNOVg/
             [83.233.237.208]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKSP+L5mjXBT5UqCi9/rHWFAeMCqhGyxYVbSQfmDkNuB
-            [83.233.237.207]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICK+q9cT0xsLeMQT/XI7DpTYB8+XX21h1vOWk+9/JyFx
-            [83.233.237.209]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL5bwRDW4XzjrPytPvrRb/YFVrNZdXbgwg6+uOJG+Hji
+            [83.233.237.209]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICK+q9cT0xsLeMQT/XI7DpTYB8+XX21h1vOWk+9/JyFx
+            [83.233.237.210]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL5bwRDW4XzjrPytPvrRb/YFVrNZdXbgwg6+uOJG+Hji
           vault_password: ${{ secrets.VAULT_PASSWORD }}
           options: |
             --diff
@@ -61,10 +61,10 @@ jobs:
           playbook: 3-minio-oidc.yml
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           known_hosts: |
-            [83.233.237.206]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGnXbhMpfFhusPWbl0OhXDjO9m0XT51FWF7PowVNOVg/
+            [83.233.237.207]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGnXbhMpfFhusPWbl0OhXDjO9m0XT51FWF7PowVNOVg/
             [83.233.237.208]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKSP+L5mjXBT5UqCi9/rHWFAeMCqhGyxYVbSQfmDkNuB
-            [83.233.237.207]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICK+q9cT0xsLeMQT/XI7DpTYB8+XX21h1vOWk+9/JyFx
-            [83.233.237.209]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL5bwRDW4XzjrPytPvrRb/YFVrNZdXbgwg6+uOJG+Hji
+            [83.233.237.209]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICK+q9cT0xsLeMQT/XI7DpTYB8+XX21h1vOWk+9/JyFx
+            [83.233.237.210]:622 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL5bwRDW4XzjrPytPvrRb/YFVrNZdXbgwg6+uOJG+Hji
           vault_password: ${{ secrets.VAULT_PASSWORD }}
           options: |
             --diff

--- a/0-bootstrap.yml
+++ b/0-bootstrap.yml
@@ -2,6 +2,10 @@
 
 - hosts: minio_microk8s_servers
   become: yes
+  # One host at a time: the microk8s-node role can restart kubelite, and
+  # restarting the control plane on every node at once would cost dqlite
+  # its quorum.
+  serial: 1
   roles:
     - common
     - role: microk8s-node

--- a/0-bootstrap.yml
+++ b/0-bootstrap.yml
@@ -2,10 +2,6 @@
 
 - hosts: minio_microk8s_servers
   become: yes
-  # One host at a time: the microk8s-node role can restart kubelite, and
-  # restarting the control plane on every node at once would cost dqlite
-  # its quorum.
-  serial: 1
   roles:
     - common
     - role: microk8s-node

--- a/docs/hacks-and-troubleshooting.md
+++ b/docs/hacks-and-troubleshooting.md
@@ -55,3 +55,54 @@ When the driver is installed as intended, the driver should be listed by `lsmod`
     'r8125                 233472  0'
 
 If the `r8125` driver is not listed, then we have problems.
+
+
+WiFi Disabled on All Cluster Nodes
+----------------------------------
+
+All four nodes (`a12a`–`a12d`) have built-in WiFi that was originally kept as an
+out-of-band fallback onto the `A12-local` SSID (`192.168.0.0/24`). Interface names
+differ per model: `wlo1` on a12a/a12b, `wlp3s0` on a12c, `wlp4s0` on a12d.
+
+**As of 2026-08-14 the WiFi is disabled on every node.** Two reasons:
+
+1. Kubernetes picks node identity independently of the routing table. Even with the
+   wired NIC on a lower DHCP route metric (100 vs 600), `kubelet` autodetection chose
+   the WiFi address on a12d and registered `192.168.0.19` as the node `InternalIP`,
+   sending pod traffic over the fallback network. Calico's default `first-found` IP
+   autodetection can do the same.
+2. Since all four nodes were consolidated onto site s3 (`192.168.3.207`–`.210`), the
+   wired path is the only correct one — the WiFi reaches a different site's client
+   network entirely.
+
+Disabling is done declaratively, by moving the netplan WiFi configuration out of the
+way. The file — including the SSID credentials — is preserved, so nothing is lost:
+
+    sudo mv /etc/netplan/00-installer-config-wifi.yaml /etc/netplan/00-installer-config-wifi.yaml.disabled
+    sudo netplan apply
+
+Netplan only reads `*.yaml`, so after this the radio is left unconfigured and the
+interface stays `DOWN` across reboots. The wired configuration lives in a separate
+file (`00-installer-config.yaml`) and is untouched.
+
+### Re-enabling WiFi
+
+Reverse the rename and re-apply. Run `netplan apply` detached, because applying the
+configuration can briefly interrupt the SSH session you are connected over:
+
+    sudo mv /etc/netplan/00-installer-config-wifi.yaml.disabled /etc/netplan/00-installer-config-wifi.yaml
+    sudo systemd-run --no-block --unit=netplan-wifi netplan apply
+
+Verify with `ip -br a` — the wireless interface should go `UP` with a `192.168.0.x`
+address, while the wired interface keeps its `192.168.3.x` address and the default
+route (metric 100 beats metric 600).
+
+**Before re-enabling, make sure the node identity is pinned**, or the problem above
+comes straight back:
+
+* `--node-ip=<wired IP>` in `/var/snap/microk8s/current/args/kubelet`
+  (note: `microk8s join` wipes this file, so set it *after* joining)
+* `--advertise-address=<wired IP>` in `/var/snap/microk8s/current/args/kube-apiserver`
+* optionally pin Calico with `IP_AUTODETECTION_METHOD: "cidr=192.168.3.0/24"`
+
+Restart `snap.microk8s.daemon-kubelite` after changing either argument file.

--- a/hosts.yml
+++ b/hosts.yml
@@ -4,7 +4,7 @@ minio_microk8s_servers:
   hosts:
     # a12a.mabl.online
     node-1:
-      ansible_host: 83.233.237.206
+      ansible_host: 83.233.237.207
       ansible_port: 622
       ansible_user: owntube_ansible
     # a12b.mabl.online
@@ -14,12 +14,12 @@ minio_microk8s_servers:
       ansible_user: owntube_ansible
     # a12c.mabl.online
     node-3:
-      ansible_host: 83.233.237.207
+      ansible_host: 83.233.237.209
       ansible_port: 622
       ansible_user: owntube_ansible
     # a12d.mabl.online
     node-4:
-      ansible_host: 83.233.237.209
+      ansible_host: 83.233.237.210
       ansible_port: 622
       ansible_user: owntube_ansible
 

--- a/roles/microk8s-cluster/tasks/k8s-configurations.yml
+++ b/roles/microk8s-cluster/tasks/k8s-configurations.yml
@@ -5,6 +5,10 @@
     path: /root/.kube
     state: directory
     mode: 0750
+  # Every kubernetes.core.k8s task below reads this kubeconfig, in check mode
+  # too. Skipping these two would leave whatever the file happened to contain
+  # from an earlier run — a stale API server address then fails the check.
+  check_mode: no
   tags: microk8s-cluster
 
 - name: Create root kubectl config for the MicroK8s designated host
@@ -12,6 +16,7 @@
   args:
     executable: /bin/bash
   changed_when: no
+  check_mode: no
   tags: microk8s-cluster
 
 - name: Create Let's Encrypt issuer for cert-manager

--- a/roles/microk8s-node/handlers/main.yml
+++ b/roles/microk8s-node/handlers/main.yml
@@ -1,0 +1,11 @@
+---
+
+# Deliberately without 'check_mode: no' — a --check run must not restart the
+# control plane. The playbook runs 'serial: 1', so this becomes a rolling
+# restart and the cluster keeps dqlite quorum throughout.
+- name: Restart MicroK8s kubelite
+  ansible.builtin.systemd:
+    name: snap.microk8s.daemon-kubelite
+    state: restarted
+
+...

--- a/roles/microk8s-node/handlers/main.yml
+++ b/roles/microk8s-node/handlers/main.yml
@@ -1,11 +1,16 @@
 ---
 
+# 'throttle: 1' restarts one node at a time even though the play itself runs
+# on all of them in parallel: the Kubernetes control plane stores its state in
+# dqlite, which needs a majority of nodes available, so restarting every node
+# at once would cost the cluster its quorum.
+#
 # Deliberately without 'check_mode: no' — a --check run must not restart the
-# control plane. The playbook runs 'serial: 1', so this becomes a rolling
-# restart and the cluster keeps dqlite quorum throughout.
+# control plane.
 - name: Restart MicroK8s kubelite
   ansible.builtin.systemd:
     name: snap.microk8s.daemon-kubelite
     state: restarted
+  throttle: 1
 
 ...

--- a/roles/microk8s-node/tasks/main.yml
+++ b/roles/microk8s-node/tasks/main.yml
@@ -18,6 +18,18 @@
   check_mode: no
   tags: microk8s-node
 
+- name: Pin the API server advertise address to the node's primary interface
+  # Not maintained by MicroK8s itself: the value is written once and never
+  # tracks later address changes. A stale entry leaves the 'kubernetes'
+  # Service endpoints pointing at dead IPs, which breaks the CNI and takes
+  # the pod network down with it.
+  ansible.builtin.lineinfile:
+    path: /var/snap/microk8s/current/args/kube-apiserver
+    regexp: '^--advertise-address='
+    line: '--advertise-address={{ ansible_default_ipv4.address }}'
+  notify: Restart MicroK8s kubelite
+  tags: microk8s-node
+
 - name: Create kubectl Snap alias
   community.general.snap_alias:
     name: microk8s.kubectl
@@ -58,7 +70,12 @@
       Login to the MicroK8s node {{ hostvars[inventory_hostname].ansible_default_ipv4.address }} via
       SSH and cluster it with the first host with 'microk8s join
       {{ hostvars[designated_host].ansible_default_ipv4.address }}:25000/<token>'.
-  when: inventory_hostname != designated_host
+  when:
+    - inventory_hostname != designated_host
+    # Skip rather than fail when the designated host is outside the current
+    # run, e.g. under --limit; its facts have not been gathered then, and a
+    # failed host would also keep handlers from running.
+    - hostvars[designated_host].ansible_default_ipv4 is defined
   tags: microk8s-node
 
 ...


### PR DESCRIPTION
All four cluster nodes have been physically consolidated onto a single site, `a12-eoc-s3`, and every node changed IP address in the process. This PR brings the repository in line with that.

The interesting part is what the move exposed. **Three separate settings held an address that was written down once, at provisioning time, and never revisited.** Each looked fine for as long as the addresses never changed, and each broke the moment they did — one of them taking the entire cluster's pod network down. Three of the six commits are about replacing such frozen values with values derived from the machines themselves.

## Background, for reviewers new to this stack

A few terms that appear throughout, in case they are unfamiliar:

**Ansible** is the tool this repo is built around. It connects to servers over SSH and makes them match a description written in YAML. Nothing runs on the servers permanently — you run a *playbook* (e.g. `0-bootstrap.yml`) and it brings every listed machine to the desired state. The list of machines lives in `hosts.yml`, the *inventory*.

**Roles** are reusable bundles of steps. `roles/microk8s-node/` describes what a Kubernetes node should look like; `roles/minio-server/` does the same for storage.

**Facts** are values Ansible discovers about each machine at connect time. `ansible_default_ipv4.address` is "the IP address this machine uses for its default route" — i.e. its real, current address. Deriving configuration from facts rather than hardcoding it is the central idea in this PR.

**Handlers** are steps that only run if something actually changed. "If you edited this config file, restart the service" — but only once, and only when needed.

**Check mode** (`--check`) is a dry run: Ansible reports what it *would* change without changing anything. CI uses it to review a PR against the live servers safely.

**MicroK8s** is the Kubernetes distribution running on these nodes; `kubelite` is the single process that hosts its control plane components.

## The six commits

### 1. Update inventory for the new addresses

Bookkeeping: three of the four nodes are reachable on new public addresses. The internal address now mirrors the public one (`a12a` is `192.168.3.207` internally and `…237.207` publicly), which makes the mapping easy to remember.

### 2. Document that WiFi is disabled on all nodes

Every node has a built-in WiFi adapter that used to be kept up as a fallback path. It has now been disabled, and this commit records **why** and **how to reverse it**.

The reason is unintuitive. Linux routing preferred the wired NIC correctly — it has a lower route *metric*, so ordinary traffic always chose the cable. But **Kubernetes does not consult the routing table when deciding a node's identity.** `kubelet` runs its own autodetection, and on one node it picked the WiFi address, registering `192.168.0.19` as that node's `InternalIP`. From then on, cluster traffic aimed at that node went over the fallback network. Calico, the networking layer, has a separate autodetection that can make the same mistake independently.

With one network interface, neither can guess wrong. The netplan configuration is preserved (renamed, not deleted), so re-enabling is a rename away — the doc spells out the procedure and what must be pinned first so the problem does not return.

### 3. Keep the API server advertise address in sync — *frozen value #1*

Each node runs a Kubernetes API server that has to announce "reach me at this address". Kubernetes publishes those announcements as the endpoints of a service called `kubernetes`, which everything in the cluster uses to reach the control plane.

MicroK8s writes that address into an argument file once, at install time, and never revisits it. After the move, all four files still held the *old* addresses, and the consequences cascaded:

1. The `kubernetes` service endpoints listed four addresses that no longer existed.
2. `kube-proxy` faithfully redirected the internal cluster IP `10.152.183.1` to those dead addresses.
3. `calico-node` needs to reach that cluster IP during startup to fetch a credential. It could not, and crash-looped.
4. Calico *is* the pod network. Without it **no pod on the cluster could start** — DNS, ingress, certificate management, everything sat in `ContainerCreating`.

The instructive part: restarting the cluster does not help, because the wrong value is written down in a file and gets loaded again on every restart. It has to be corrected at the source.

The fix derives the value from `ansible_default_ipv4` — the same mechanism the MinIO role already uses to generate `/etc/hosts` — and restarts `kubelite` through a handler when it changes.

This commit also carries a bug fix it depends on. Repairing a single node is naturally done with `--limit`, and that path was broken: an informational task prints a hint containing the *first* node's address, but under `--limit` that node was never contacted, so the fact does not exist and the task fails. Ansible then marks the host failed and **skips its handlers**, silently swallowing the restart. The hint is now skipped instead of failing.

### 4. Remap the workflow `known_hosts` — *frozen value #2*

SSH refuses to connect to a host whose key does not match the one it has on file — that is what protects you from someone impersonating a server. The CI and CD workflows carry a fixed list of "this address has this key".

The keys never changed; **which machine sits behind each address did.** `a12a` moved from `.206` to `.207`, `a12c` from `.207` to `.209`, `a12d` from `.209` to `.210`. So SSH correctly reported `REMOTE HOST IDENTIFICATION HAS CHANGED` and CI could not connect at all. The entries are remapped, and `.206` is dropped since it now serves site `a12-eoc-s1` rather than a cluster node.

### 5. Refresh the root kubeconfig in check mode — *frozen value #3*

A *kubeconfig* is the file that tells `kubectl` and Ansible's Kubernetes modules where the cluster is and how to authenticate. This role generates one at `/root/.kube/config`.

Ansible skips file and shell tasks in check mode, so a `--check` run never regenerated it and used whatever an earlier run had left behind. That was invisible for as long as the leftover file pointed at the right place. After the move it pointed at `192.168.1.6`, which no longer exists, and CI failed with `No route to host` before reaching a single assertion.

Marking those two tasks `check_mode: no` makes them run for real even during a dry run — appropriate here, since every later task depends on the file and generating it changes nothing about the cluster.

### 6. Throttle the restart instead of serialising the whole play

Restarting the control plane on all four nodes simultaneously would be dangerous: Kubernetes stores its state in `dqlite`, which needs a majority of nodes available, so a simultaneous restart costs the cluster its quorum.

The first approach was `serial: 1`, which makes Ansible walk the *entire* play one host at a time — a heavy price for a guarantee only one task needs. `throttle: 1` is the narrower tool: it limits concurrency for a single task no matter how parallel the play is. The play runs at full width again and only the restart is serialised.

## Verification

These were tested against the live cluster rather than only reasoned about.

**The advertise address task and its handler**, by deliberately deleting the setting on one node and running with `--limit`:

1. The first attempt exposed the `--limit` bug — the value was rewritten correctly, but the recap showed `failed=1` and the restart never happened. That is what motivated the guard in commit 3.
2. After the guard, the run reported `changed=2` — the setting *and* the handler — and the service restart timestamp confirmed `kubelite` had genuinely restarted.

Deleting the value rather than setting a wrong one kept the test safe: with the setting absent the API server falls back to autodetection and picks the same address anyway.

**That `throttle: 1` actually applies to handlers**, by clearing the setting on two nodes at once and running against both. The restarts landed **0.9 s apart** rather than simultaneously — parallel dispatch would have been milliseconds apart — so the serialisation is real and quorum is preserved.

**Cluster state afterwards:** all four nodes `Ready`, 21 pods `Running`, the `kubernetes` endpoints listing the four current addresses, and storage healthy across all 32 drives.

## Still hand-maintained

`--node-ip` for `kubelet` and Calico's `IP_AUTODETECTION_METHOD` are still set by hand. With WiFi disabled both autodetect correctly, so this is not urgent — but they are the same kind of frozen value as the three above, and the same "derive it from facts" treatment would make the cluster fully reproducible from this repository.
